### PR TITLE
Fix typo

### DIFF
--- a/src/roadmaps/frontend.ts
+++ b/src/roadmaps/frontend.ts
@@ -331,7 +331,7 @@ export const data: Level[] = [
             ],
           },
           {
-            label: "Serviçoes de Hospedagem de Git",
+            label: "Serviços de Hospedagem de Git",
             children: [
               {
                 label: "Github",


### PR DESCRIPTION
~Serviçoes~ de Hospedagem de Git => **Serviços** de Hospedagem de Git