### PR TITLE
Corrige overflow-x do viewport

### DIFF
--- a/src/components/CheatSheets/CheatSheets.tsx
+++ b/src/components/CheatSheets/CheatSheets.tsx
@@ -17,7 +17,7 @@ export default function CheatSheets() {
   return (
     <>
       
-        <div className="flex flex-col items-stretch justify-center bg-[#403C3B] my-10 py-10 mx-0 w-screen shadow-inner">
+        <div className="flex flex-col items-stretch justify-center bg-[#403C3B] my-10 py-10 mx-0 w-full shadow-inner">
           <h2 className="text-center my-6 txt-handwritten text-3xl c-yellow">
             Guias (Cheat Sheets)
           </h2>

--- a/src/components/UserArea/UserArea.tsx
+++ b/src/components/UserArea/UserArea.tsx
@@ -93,7 +93,7 @@ export default function UserArea() {
   return (
     <>
       {isAuthenticated && (
-        <div className="flex flex-col items-stretch justify-center bg-[#403C3B] my-10 py-10 mx-0 w-screen shadow-inner">
+        <div className="flex flex-col items-stretch justify-center bg-[#403C3B] my-10 py-10 mx-0 w-full shadow-inner">
           <h2 className="text-center my-6 txt-handwritten text-3xl c-yellow">
             Meus Roadmaps
           </h2>

--- a/src/components/layouts/MainLayout.tsx
+++ b/src/components/layouts/MainLayout.tsx
@@ -23,7 +23,7 @@ export default function MainLayout({ children }: Props) {
   return (
     <>
       <div className="flex flex-col h-screen">
-        <div className="w-screen p-2 flex flex-wrap space-x-0 space-y-2 mx-auto bg-[#2A2827] shadow-md">
+        <div className="w-full p-2 flex flex-wrap space-x-0 space-y-2 mx-auto bg-[#2A2827] shadow-md">
           <div className="flex-grow">
             {" "}
             <Logo />
@@ -89,10 +89,10 @@ export default function MainLayout({ children }: Props) {
             
           </div>
         </div>
-        <div className="w-screen flex-grow py-1 mx-auto mt-0 mb-10">
+        <div className="w-full flex-grow py-1 mx-auto mt-0 mb-10">
           {children}
         </div>
-        <footer className="text-center py-4 w-screen bg-dark-brown">
+        <footer className="text-center py-4 w-full bg-dark-brown">
           <span className="c-brown">Idealizado por </span>
           <ChakraLink
             isExternal

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -126,7 +126,7 @@ export default function HomePage() {
               conhecimento chegue cada vez mais longe.
             </p>
           </div>
-          <div className="w-screen mt-4 flex justify-center">
+          <div className="w-full mt-4 flex justify-center">
             <iframe
               src="https://ghbtns.com/github-btn.html?user=flaviojmendes&repo=trilhainfo&type=star&count=true&size=large&v=2"
               scrolling="0"


### PR DESCRIPTION
Substituídas classes do Tailwind CSS `.w-screen` por `.w-full` nos componentes, com fins de evitar _scroll_ horizontal desnecessário em determinados elementos.
Em navegadores WebKit, especialmente, ao redimensionar a janela, alguns elementos apresentavam `overflow-x` como segue:

![Captura de tela exibindo scroll horizontal](https://user-images.githubusercontent.com/4587838/189498399-6001a400-a083-4454-b022-e4e083f54193.png)
