### PR TITLE
Fix: Duplicated React Native session in Mobile Apps

### DIFF
--- a/src/roadmaps/frontend.ts
+++ b/src/roadmaps/frontend.ts
@@ -600,44 +600,44 @@ export const data: Level[] = [
             label: "React Hooks",
             links: [
               {
-                  url: "https://www.youtube.com/watch?v=Jxe79XZ9u-Y",
-                  label: "React Hook useState - Huriel",
-                  contentType: LinkContentType.WATCH,
+                url: "https://www.youtube.com/watch?v=Jxe79XZ9u-Y",
+                label: "React Hook useState - Huriel",
+                contentType: LinkContentType.WATCH,
               },
               {
-                  url: "https://www.youtube.com/watch?v=NPw6OvXh2xk",
-                  label: "React Hook useEffect - Huriel",
-                  contentType: LinkContentType.WATCH,
+                url: "https://www.youtube.com/watch?v=NPw6OvXh2xk",
+                label: "React Hook useEffect - Huriel",
+                contentType: LinkContentType.WATCH,
               },
               {
-                  url: "https://www.youtube.com/watch?v=0UVYtx_C87w&t=1405s",
-                  label: "React Hook useContext - Huriel",
-                  contentType: LinkContentType.WATCH,
+                url: "https://www.youtube.com/watch?v=0UVYtx_C87w&t=1405s",
+                label: "React Hook useContext - Huriel",
+                contentType: LinkContentType.WATCH,
               },
               {
-                  url: "https://www.youtube.com/watch?v=kzAMDNBiAzs",
-                  label: "React Hook useCallback - Huriel",
-                  contentType: LinkContentType.WATCH,
+                url: "https://www.youtube.com/watch?v=kzAMDNBiAzs",
+                label: "React Hook useCallback - Huriel",
+                contentType: LinkContentType.WATCH,
               },
               {
-                  url: "https://www.youtube.com/watch?v=eypNvly4s3Q",
-                  label: "React Hook useRef - Huriel",
-                  contentType: LinkContentType.WATCH,
+                url: "https://www.youtube.com/watch?v=eypNvly4s3Q",
+                label: "React Hook useRef - Huriel",
+                contentType: LinkContentType.WATCH,
               },
               {
-                  url: "https://www.youtube.com/watch?v=LdYZ-QI0ztM",
-                  label: "React Hook useMemo - Huriel",
-                  contentType: LinkContentType.WATCH,
+                url: "https://www.youtube.com/watch?v=LdYZ-QI0ztM",
+                label: "React Hook useMemo - Huriel",
+                contentType: LinkContentType.WATCH,
               },
               {
-                  url: "https://www.youtube.com/watch?v=UCUL2JrjZ3c",
-                  label: "React Hook useReducer - Huriel",
-                  contentType: LinkContentType.WATCH,
+                url: "https://www.youtube.com/watch?v=UCUL2JrjZ3c",
+                label: "React Hook useReducer - Huriel",
+                contentType: LinkContentType.WATCH,
               },
               {
-                  url: "https://www.youtube.com/watch?v=2cTAR3EkvQ8",
-                  label: "Hooks Personalizados - Huriel",
-                  contentType: LinkContentType.WATCH,
+                url: "https://www.youtube.com/watch?v=2cTAR3EkvQ8",
+                label: "Hooks Personalizados - Huriel",
+                contentType: LinkContentType.WATCH,
               }
             ]
           },
@@ -1152,11 +1152,6 @@ export const data: Level[] = [
                 type: LinkType.FREE,
                 contentType: LinkContentType.WATCH,
               },
-            ],
-          },
-          {
-            label: "React Native",
-            links: [
               {
                 label: "Primeiros passos no React Native - One Bit Code",
                 url: "https://www.youtube.com/watch?v=Y8tP1jbRYHY&list=PLdDT8if5attEd4sRnZBIkNihR-_tE612_&index=1",
@@ -1166,7 +1161,7 @@ export const data: Level[] = [
                 label: "Aprenda React Native - Canal Geek Dev",
                 url: "https://www.youtube.com/watch?v=DmUUsTC2YkA&list=PL8fIRnD1uUSnRqz3E2caAWDqbtIFXmNtW",
                 contentType: LinkContentType.WATCH,
-              },
+              }
             ],
           },
           { label: "NativeScript", links: [] },


### PR DESCRIPTION
## Introduction
When you access the path: `Frontend` -> `Mobile Apps`, you'll see the `React Native` session duplicated, the session is duplicated but the content is not.

This PR removes the duplicity and merges these contents.

## What is the current behavior?
![image](https://user-images.githubusercontent.com/46636310/191388637-0d413eeb-e32f-4748-a128-f74a5d798394.png)

![image](https://user-images.githubusercontent.com/46636310/191388690-1493c580-7935-4df3-8bd4-eb07296bccba.png)

![image](https://user-images.githubusercontent.com/46636310/191388772-a760c7ff-e1d1-4ee2-b326-dc024a97be4c.png)

## What is the new behavior?
![image](https://user-images.githubusercontent.com/46636310/191388818-6d5a217c-8240-44c2-bbb1-b039fe97da91.png)

![image](https://user-images.githubusercontent.com/46636310/191388828-f0ffd506-dcec-4a28-b1fb-772b299ed74b.png)