### PR TITLE
feat: adiciona botão de visualizar verticalmente no componente HozirontalRoadMapPage 

### DIFF
--- a/src/components/Roadmap/Roadmap.tsx
+++ b/src/components/Roadmap/Roadmap.tsx
@@ -1,4 +1,3 @@
-import ReactGA from "react-ga4";
 import {
   Accordion,
   AccordionButton,
@@ -31,6 +30,7 @@ import Comment from "../Note/Note";
 import { Link, useLocation } from "react-router-dom";
 import { emojisplosion } from "emojisplosion";
 import Note from "../Note/Note";
+import RoadmapButtons from "../RoadmapButtons";
 
 type Props = {
   data: Level[];
@@ -57,7 +57,7 @@ function getColorFromContentType(contentType: LinkContentType | string) {
 
 export default function Roadmap(props: Props) {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const printRef = useRef(null);
+  const roadmapRef = useRef(null);
   const { pathname, hash, key } = useLocation();
   const [activeItem, setActiveItem] = React.useState<RoadmapItem>();
   const [mousePos, setMousePos] = useState<{ x: number; y: number }>();
@@ -172,62 +172,22 @@ export default function Roadmap(props: Props) {
     }
   }
 
-  async function handleDownloadImage() {
-    ReactGA.event({
-      category: "download_roadmap",
-      action: "download_" + props.title,
-    });
-
-    const element = printRef.current || document.body;
-    const data = await domtoimage.toPng(element);
-
-    const link = document.createElement("a");
-
-    if (typeof link.download === "string") {
-      link.href = data;
-      link.download = `trilha${props.title}.png`;
-
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } else {
-      window.open(data);
-    }
-  }
-
   function handleCloseDrawer() {
     window.history.pushState(props.name, props.name, `/roadmap/${props.name}`);
     onClose();
-  }
-
-  function handleHorizontalRoadmapClick() {
-    ReactGA.event({
-      category: "action",
-      action: "open_horizontal_roadmap",
-    });
   }
 
   return (
     <>
       <div className={props.isPreview ? "hidden" : "flex"}>
         <div className="flex-grow"></div>
-        <a
-          type="button"
-          className="border-2 p-1 rounded-md bg-light-orange txt-title border-red m-auto mr-2 hover:shadow-md hover:bg-light-orange"
-          href={`/hroadmap/${props.name}`}
-          onClick={handleHorizontalRoadmapClick}
-        >
-          Visualizar na Horizontal
-        </a>
-        <button
-          type="button"
-          className="border-2 p-1 rounded-md bg-yellow txt-title border-yellow m-auto mr-2 md:mr-10 hover:shadow-md hover:bg-light-orange"
-          onClick={handleDownloadImage}
-        >
-          Baixar meu Roadmap
-        </button>
+        <RoadmapButtons
+          buttons={["horizontalView", "download"]}
+          title={props.title}
+          roadmapRef={roadmapRef}
+        />
       </div>
-      <section ref={printRef} className="pb-8">
+      <section ref={roadmapRef} className="pb-8">
         <h2
           className={`text-center font-bold text-3xl c-yellow my-6 txt-title c-dark-brown ${
             props.isPreview ? "hidden" : ""

--- a/src/components/RoadmapButtons/ButtonElement.tsx
+++ b/src/components/RoadmapButtons/ButtonElement.tsx
@@ -1,0 +1,50 @@
+import { ReactElement } from "react";
+import ReactGA from "react-ga4";
+import { ButtonArgs } from "./types";
+
+type ButtonElementProps = ButtonArgs;
+
+const ButtonElement = ({
+  type,
+  category,
+  analyticsActionTag,
+  text,
+  ...args
+}: ButtonElementProps): ReactElement => {
+  function handleAnalyticsEvent() {
+    ReactGA.event({
+      category,
+      action: analyticsActionTag,
+    });
+  }
+
+  const renderLinkButton = (
+    <a
+      type="button"
+      href={args.href}
+      className="border-2 p-1 rounded-md bg-light-orange txt-title border-red mr-2 hover:shadow-md hover:bg-light-orange"
+      onClick={handleAnalyticsEvent}
+    >
+      {text}
+    </a>
+  );
+
+  const renderButton = (
+    <button
+      type="button"
+      className="border-2 p-1 rounded-md bg-yellow txt-title border-yellow mr-2 md:mr-10 hover:shadow-md hover:bg-light-orange"
+      onClick={args.action}
+    >
+      {text}
+    </button>
+  );
+
+  const buttonElements = {
+    link: renderLinkButton,
+    button: renderButton,
+  };
+
+  return buttonElements[type];
+};
+
+export default ButtonElement;

--- a/src/components/RoadmapButtons/index.tsx
+++ b/src/components/RoadmapButtons/index.tsx
@@ -1,0 +1,79 @@
+import ButtonElement from "./ButtonElement";
+import domtoimage from "dom-to-image";
+import { MutableRefObject } from "react";
+import { Button, ButtonArgs } from "./types";
+
+type RoadmapButtonsProps = {
+  buttons: Button[];
+  roadmapRef: MutableRefObject<null>;
+  title: string;
+};
+
+const RoadmapButtons = ({
+  buttons,
+  roadmapRef,
+  title,
+}: RoadmapButtonsProps) => {
+  const handleDownloadImage = async () => {
+    const element = roadmapRef.current || document.body;
+    const data = await domtoimage.toPng(element);
+
+    const link = document.createElement("a");
+
+    if (typeof link.download === "string") {
+      link.href = data;
+      link.download = `trilha${title}.png`;
+
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else {
+      window.open(data);
+    }
+  };
+
+  const BUTTON_ACTIONS: Map<Button, ButtonArgs> = new Map([
+    [
+      "verticalView",
+      {
+        text: "Visualizar Verticalmente",
+        type: "link",
+        category: "download_roadmap",
+        analyticsActionTag: "open_vertical_roadmap",
+        href: `/roadmap/${title.toLowerCase()}`,
+      },
+    ],
+    [
+      "horizontalView",
+      {
+        text: "Visualizar Horizontalmente",
+        type: "link",
+        category: "action",
+        analyticsActionTag: "open_horizontal_roadmap",
+        href: `/hroadmap/${title.toLowerCase()}`,
+      },
+    ],
+    [
+      "download",
+      {
+        text: "Baixar meu Roadmap",
+        type: "button",
+        category: "action",
+        analyticsActionTag: "download_" + title,
+        action: handleDownloadImage,
+      },
+    ],
+  ]);
+
+  return (
+    <>
+      {buttons.map((button: Button) => {
+        const buttonArgs = BUTTON_ACTIONS.get(button);
+
+        return buttonArgs && <ButtonElement {...buttonArgs} />;
+      })}
+    </>
+  );
+};
+
+export default RoadmapButtons;

--- a/src/components/RoadmapButtons/types.ts
+++ b/src/components/RoadmapButtons/types.ts
@@ -1,0 +1,12 @@
+export type Button = "verticalView" | "horizontalView" | "download";
+
+export type ButtonElementTypes = "link" | "button";
+
+export type ButtonArgs = {
+  text: string;
+  type: ButtonElementTypes;
+  category: string;
+  analyticsActionTag: string;
+  href?: string;
+  action?: () => void;
+};

--- a/src/pages/HorizontalRoadmapPage.tsx
+++ b/src/pages/HorizontalRoadmapPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useParams } from "react-router-dom";
 import MainLayout from "../components/layouts/MainLayout";
 import useDocumentTitle from "../components/useDocumentTitle";
@@ -31,12 +31,14 @@ import { CheckIcon } from "@chakra-ui/icons";
 import HorizontalLevelItem from "../components/HorizontalRoadmap/HorizontalLevelItem/HorizontalLevelItem";
 import HorizontalRoadmapFooter from "../components/HorizontalRoadmap/HorizontalRoadmapFooter/HorizontalRoadmapFooter";
 import Note from "../components/Note/Note";
+import RoadmapButtons from "../components/RoadmapButtons";
 
 export default function HorizontalRoadmapPage() {
   const { name } = useParams<string>();
   const [roadmapName, setRoadmapName] = useState("");
   const [roadmapData, setRoadmapData] = useState<Level[]>();
   const [roadmapLevel, setRoadmapLevel] = useState<Level>();
+  const roadmapRef = useRef(null);
   const [selectedItem, setSelectedItem] = useState<RoadmapItem>();
   const [currentLevelIndex, setCurrentLevelIndex] = useState(0);
   const [mousePos, setMousePos] = useState<{ x: number; y: number }>();
@@ -184,132 +186,144 @@ export default function HorizontalRoadmapPage() {
   return (
     <MainLayout>
       <div className="m-auto h-full flex flex-col w-11/12">
-      <h1 className="m-auto mt-8 text-center txt-title text-4xl text-yellow xl:hidden">
-              {roadmaps[name || ""].title}
-            </h1>
-        <div className="flex flex-col xl:flex-row">
-          <div className="w-full xl:w-1/4 flex-col">
-            <div className="flex-col my-8 space-y-4">
-              <HorizontalLevelItem
-                checkAllContent={checkAllContent}
-                isAllContentRead={isAllContentRead}
-                levelsQty={roadmapData?.length || 0}
-                roadmapLevel={roadmapLevel}
-                handleSelectItem={handleSelectItem}
-                index={currentLevelIndex}
-                selectedItem={selectedItem}
-              />
-            </div>
-          </div>
-          {/* Selected Item Content */}
-          <div className="w-full xl:w-2/4 xl:pl-10">
-            <h1 className="m-auto my-8 text-center txt-title text-4xl text-yellow hidden xl:block">
-              {roadmaps[name || ""].title}
-            </h1>
-            {!selectedItem && (
-              <div className="flex h-full ">
-                <p className="m-auto txt-title text-red">
-                  Selecione um Item à esquerda para estudar.
-                </p>
-              </div>
-            )}
-            {selectedItem && (
-              <div className="flex flex-col px-4">
-                <h2 className="txt-title text-2xl text-light-orange">
-                  {selectedItem.label}
-                </h2>
-                <p className="txt-title text-xl text-light-orange mt-2">
-                  {selectedItem.description}
-                </p>
-                <Accordion className="mt-4" allowToggle>
-                  {selectedItem?.children?.map((child, index) => {
-                    const key = child.label + "-" + selectedItem.label;
-
-                    return (
-                      <AccordionItem key={child.label}>
-                        <h2 className="font-semibold">
-                          <AccordionButton color={"#e9dad5"}>
-                            <Box flex="1" textAlign="left">
-                              <CheckboxGroup>
-                                <Checkbox
-                                  className="my-auto mr-2"
-                                  size={"lg"}
-                                  isChecked={isRead(key)}
-                                  onChange={(e) => {
-                                    saveRead(key, e.target.checked);
-                                  }}
-                                ></Checkbox>
-                              </CheckboxGroup>
-                              <span className="text-light-brown txt-title">
-                                {child.label}
-                              </span>
-                            </Box>
-                            <AccordionIcon />
-                          </AccordionButton>
-                        </h2>
-                        <AccordionPanel pb={4}>
-                          {child.links?.length
-                            ? child.links?.map((link, index) => {
-                                return (
-                                  <>
-                                    <Flex className="my-2">
-                                      <a
-                                        href={link.url}
-                                        target="_blank"
-                                        className="text-light-brown hover:underline"
-                                      >
-                                        {link.label}
-                                      </a>
-                                      <Spacer />
-                                      <Badge
-                                        colorScheme={getColorFromContentType(
-                                          link.contentType
-                                        )}
-                                        p={1}
-                                        rounded={"md"}
-                                        className="h-5"
-                                        fontSize="0.6em"
-                                        mr="1"
-                                        cursor={"default"}
-                                      >
-                                        <span>
-                                          {link.contentType
-                                            ? link.contentType
-                                            : null}
-                                        </span>
-                                      </Badge>
-                                    </Flex>
-                                  </>
-                                );
-                              })
-                            : "Ainda não possuimos conteúdo."}
-                        </AccordionPanel>
-                      </AccordionItem>
-                    );
-                  })}
-                </Accordion>
-              </div>
-            )}
-          </div>
-          <div className="w-full xl:w-1/4 xl:pl-10">
-            {selectedItem && (
-              <Note
-                id={selectedItem?.label || ""}
-                title={selectedItem?.label || ""}
-              />
-            )}
-          </div>
-        </div>
-        <div className="flex-grow"></div>
-        <div className="flex">
-          <HorizontalRoadmapFooter
-            currentLevelIndex={currentLevelIndex + 1}
-            levelQty={roadmapData?.length}
-            handleNextLevel={handleNextLevel}
-            handlePreviousLevel={handlePreviousLevel}
-            handleNavigateLevel={handleNavigateLevel}
+        <div className="flex justify-end gap-2 mt-8">
+          <RoadmapButtons
+            buttons={["verticalView"]}
+            title={roadmaps[name || ""].title}
+            roadmapRef={roadmapRef}
           />
         </div>
+        <section
+          ref={roadmapRef}
+          className="m-auto h-full flex flex-col w-11/12"
+        >
+          <h1 className="m-auto mt-8 text-center txt-title text-4xl text-yellow xl:hidden">
+            {roadmaps[name || ""].title}
+          </h1>
+          <div className="flex flex-col xl:flex-row">
+            <div className="w-full xl:w-1/4 flex-col">
+              <div className="flex-col my-8 space-y-4">
+                <HorizontalLevelItem
+                  checkAllContent={checkAllContent}
+                  isAllContentRead={isAllContentRead}
+                  levelsQty={roadmapData?.length || 0}
+                  roadmapLevel={roadmapLevel}
+                  handleSelectItem={handleSelectItem}
+                  index={currentLevelIndex}
+                  selectedItem={selectedItem}
+                />
+              </div>
+            </div>
+            {/* Selected Item Content */}
+            <div className="w-full xl:w-2/4 xl:pl-10">
+              <h1 className="m-auto my-8 text-center txt-title text-4xl text-yellow hidden xl:block">
+                {roadmaps[name || ""].title}
+              </h1>
+              {!selectedItem && (
+                <div className="flex h-full ">
+                  <p className="m-auto txt-title text-red">
+                    Selecione um Item à esquerda para estudar.
+                  </p>
+                </div>
+              )}
+              {selectedItem && (
+                <div className="flex flex-col px-4">
+                  <h2 className="txt-title text-2xl text-light-orange">
+                    {selectedItem.label}
+                  </h2>
+                  <p className="txt-title text-xl text-light-orange mt-2">
+                    {selectedItem.description}
+                  </p>
+                  <Accordion className="mt-4" allowToggle>
+                    {selectedItem?.children?.map((child, index) => {
+                      const key = child.label + "-" + selectedItem.label;
+
+                      return (
+                        <AccordionItem key={child.label}>
+                          <h2 className="font-semibold">
+                            <AccordionButton color={"#e9dad5"}>
+                              <Box flex="1" textAlign="left">
+                                <CheckboxGroup>
+                                  <Checkbox
+                                    className="my-auto mr-2"
+                                    size={"lg"}
+                                    isChecked={isRead(key)}
+                                    onChange={(e) => {
+                                      saveRead(key, e.target.checked);
+                                    }}
+                                  ></Checkbox>
+                                </CheckboxGroup>
+                                <span className="text-light-brown txt-title">
+                                  {child.label}
+                                </span>
+                              </Box>
+                              <AccordionIcon />
+                            </AccordionButton>
+                          </h2>
+                          <AccordionPanel pb={4}>
+                            {child.links?.length
+                              ? child.links?.map((link, index) => {
+                                  return (
+                                    <>
+                                      <Flex className="my-2">
+                                        <a
+                                          href={link.url}
+                                          target="_blank"
+                                          className="text-light-brown hover:underline"
+                                        >
+                                          {link.label}
+                                        </a>
+                                        <Spacer />
+                                        <Badge
+                                          colorScheme={getColorFromContentType(
+                                            link.contentType
+                                          )}
+                                          p={1}
+                                          rounded={"md"}
+                                          className="h-5"
+                                          fontSize="0.6em"
+                                          mr="1"
+                                          cursor={"default"}
+                                        >
+                                          <span>
+                                            {link.contentType
+                                              ? link.contentType
+                                              : null}
+                                          </span>
+                                        </Badge>
+                                      </Flex>
+                                    </>
+                                  );
+                                })
+                              : "Ainda não possuimos conteúdo."}
+                          </AccordionPanel>
+                        </AccordionItem>
+                      );
+                    })}
+                  </Accordion>
+                </div>
+              )}
+            </div>
+            <div className="w-full xl:w-1/4 xl:pl-10">
+              {selectedItem && (
+                <Note
+                  id={selectedItem?.label || ""}
+                  title={selectedItem?.label || ""}
+                />
+              )}
+            </div>
+          </div>
+          <div className="flex-grow"></div>
+          <div className="flex">
+            <HorizontalRoadmapFooter
+              currentLevelIndex={currentLevelIndex + 1}
+              levelQty={roadmapData?.length}
+              handleNextLevel={handleNextLevel}
+              handlePreviousLevel={handlePreviousLevel}
+              handleNavigateLevel={handleNavigateLevel}
+            />
+          </div>
+        </section>
       </div>
     </MainLayout>
   );


### PR DESCRIPTION
**Por que esse Pull Request foi aberto?**

Foi aberta uma [Issue](https://github.com/flaviojmendes/trilhainfo/issues/165) com falta de um botão que volte a visualização para horizontal após mudar a orientação do roadmap para vertical.

**Quais alterações foram feitas?**

Foi criada uma nova estrutura de botões para abstrair e armazenar as resposabilidades dos botões referentes aos roadmaps, visando as seguintes vantagens: 

 * Maior facilidade de integraçãos e remoções de novos botões
 * Maior facilidade em integrar estes mesmos botões em qualquer outra parte do código
 * Encapsula as ações, estilização e responsabilidades em um componente separado, deixando assim o código das páginas de roadmaps mais enxuto e legível, facilitando também a manutenção e testabilidade.

**O que mudou no código?**

 * Criação do componente `<RoadmapButtons />` assim como suas tipagens e componente auxiliar `<ButtonElement />`
 * A função `handleDownloadImage` passa para dentro do componente `<RoadmapButtons />`  atrelada ao botão de downlaod
 * A função `handleHorizontalRoadmapClick` passa para dentro do componente `<ButtonElement />` realizando um evento do Google Analytics para cada ação realizada. Sendo genérica para qualquer botão
 * Integra o componente `<Roadmap />` com os botões de "Visualização Horizontal" e "Baixar RoadMap" do componente  `<RoadmapButtons />`
 * Integra o componente `<HorizontalRoadmapPage/>` com os botões de "Visualização Vertical" do componente  `<RoadmapButtons />`
