### PR TITLE
Bugfix/collaborators image

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ yarn dev
 ## Quem já contribuiu:
 
 <a href = "https://github.com/flaviojmendes/trilhainfo/graphs/contributors">
-  <img src = "https://contrib.rocks/image?repo=flaviojmendes/trilhainfo"/>
+  <img src = "https://contributors-img.web.app/image?repo=flaviojmendes/trilhainfo" alt="Quem já contribuiu" />
 </a>
 
 ## Contribuição

--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ $ yarn dev
 
 ## Quem já contribuiu:
 
-<a href = "https://github.com/flaviojmendes/trilhainfo/graphs/contributors">
-  <img src = "https://contributors-img.web.app/image?repo=flaviojmendes/trilhainfo" alt="Quem já contribuiu" />
-</a>
+<p align="center">
+  <a href = "https://github.com/flaviojmendes/trilhainfo/graphs/contributors">
+    <img src = "https://contributors-img.web.app/image?repo=flaviojmendes/trilhainfo" alt="Quem já contribuiu" />
+  </a>
+</p>
 
 ## Contribuição
 Pull requests são bem-vindos. Para grandes mudanças, por favor, abra primeiro uma issue para discutir o que gostaria de mudar.


### PR DESCRIPTION
Problem: collaborators image not loading

Solution: update the image url with the new host of contrib.rocks
