### PR TITLE
feat(unix): Apostila de AIX adicionada

### DIFF
--- a/src/roadmaps/devops.ts
+++ b/src/roadmaps/devops.ts
@@ -6,6 +6,7 @@ import { python } from './items/python';
 import { rust } from './items/rust';
 import { ruby } from './items/ruby';
 import { cplusplus } from './items/cplusplus';
+import { unix } from './items/unix';
 
 export const data: Level[] = [
   {
@@ -170,15 +171,7 @@ export const data: Level[] = [
           { label: 'NetBSD', links: [] },
         ],
       },
-      {
-        label: 'UNIX',
-        description: 'UNIX é um sistema operacional portável, multitarefa e multiusuário originalmente criado por Ken Thompson, Dennis Ritchie, entre outros, que trabalhavam nos Laboratórios Bell da AT&T.',
-        children: [
-          { label: 'AIX', links: [] },
-          { label: 'Solaris', links: [] },
-          { label: 'MINIX', links: [] },
-        ],
-      },
+      unix,
       { label: 'Windows', children: [{ label: 'O básico', links: [] }] },
     ],
   },

--- a/src/roadmaps/items/unix.ts
+++ b/src/roadmaps/items/unix.ts
@@ -1,0 +1,19 @@
+import { LinkContentType, RoadmapItem } from '../../entity/RoadmapModel';
+
+export const unix: RoadmapItem = {
+  label: 'UNIX',
+  description: 'UNIX é um sistema operacional portável, multitarefa e multiusuário originalmente criado por Ken Thompson, Dennis Ritchie, entre outros, que trabalhavam nos Laboratórios Bell da AT&T.',
+  children: [
+    {
+      label: 'AIX', links: [
+        {
+          label: 'UNICAMP - CCUEC - Apostila de AIX',
+          url: 'http://www.dicas-l.com.br/download/aix.pdf',
+          contentType: LinkContentType.WATCH,
+        },
+      ]
+    },
+    { label: 'Solaris', links: [] },
+    { label: 'MINIX', links: [] },
+  ],
+}

--- a/src/roadmaps/items/unix.ts
+++ b/src/roadmaps/items/unix.ts
@@ -9,7 +9,7 @@ export const unix: RoadmapItem = {
         {
           label: 'UNICAMP - CCUEC - Apostila de AIX',
           url: 'http://www.dicas-l.com.br/download/aix.pdf',
-          contentType: LinkContentType.WATCH,
+          contentType: LinkContentType.VISIT,
         },
       ]
     },


### PR DESCRIPTION
Do Dicas-L, temos:

Curso de IBM AIX
Colaboração: Rubens Queiroz de Almeida

Data de Publicação: 06 de Maio de 1999

Há muito tempo atrás eu desenvolvi um curso de AIX. Era abordada na época a versão 3. O AIX já evoluiu bastante desde então mas o curso, embora não seja mais ministrado, ainda contém informações atualizadas e úteis sobre vários aspectos do sistema AIX.

Eu estou disponibilizando no site da Dicas-L, no endereço http://www.dicas-l.com.br/download/aix.pdf o material deste curso no formato PDF. O curso está estruturado com as transparências no lado esquerdo e os comentários no lado direito. A apostila tem 196 páginas. A numeração do índice possivelmente está errada, mas eu não vou corrigir.

Resumindo, o material pode ser útil para quem quer obter mais informações sobre AIX e está em português. Façam bom proveito.

Para se ler documentos no formato PDF é necessário utilizar o software Adobe Acrobat Reader, disponível gratuitamente no site da Adobe (http://www.adobe.com).

Fonte: https://www.dicas-l.com.br/arquivo/curso_de_ibm_aix.php