### PR TITLE
feat: adicionando trilha de cybersec

### DIFF
--- a/src/components/MainRoadmaps/mainRoadmapsData.ts
+++ b/src/components/MainRoadmaps/mainRoadmapsData.ts
@@ -49,4 +49,11 @@ export const mainRoadmapsData = [
     url: '/roadmap/test',
     image: '/test.png',
   },
+  {
+    title: 'Cibersegurança',
+    description:
+      'Aprenda sobre cibersegurança, um campo que se concentra na proteção de sistemas, redes e programas de computador contra roubo, danos ou acesso não autorizado.',
+    url: '/roadmap/cybersec',
+    image: '/cybersec.png',
+  },
 ];

--- a/src/entity/RoadmapFileModel.tsx
+++ b/src/entity/RoadmapFileModel.tsx
@@ -15,4 +15,5 @@ export interface RoadmapFileModel {
   test: RoadmapObjectModel;
   fullstack: RoadmapObjectModel;
   entrevistas: RoadmapObjectModel;
+  cybersec: RoadmapObjectModel;
 }

--- a/src/roadmaps/roadmaps.ts
+++ b/src/roadmaps/roadmaps.ts
@@ -6,6 +6,7 @@ import { data as testData } from '../roadmaps/test';
 import { data as communityData } from '../roadmaps/community';
 import { data as fullstackData } from '../roadmaps/fullstack';
 import { data as entrevistasData } from '../roadmaps/entrevistas';
+import { data as cybersecData } from '../roadmaps/cybersec';
 import { dataEngineeringData } from '../roadmaps/dataEngineering';
 import { RoadmapFileModel } from '../entity/RoadmapFileModel';
 
@@ -19,4 +20,5 @@ export const roadmaps: RoadmapFileModel = {
   community: { file: communityData, title: 'Comunidade' },
   test: { file: testData, title: 'Test/QA' },
   entrevistas: { file: entrevistasData, title: 'Entrevistas' },
+  cybersec: { file: cybersecData, title: 'Cibersegurança' },
 };


### PR DESCRIPTION
Iniciei a trilha de cybersec segundo a ideia de uma issue, o roadmap é baseado [neste](src/components/MainRoadmaps/mainRoadmapsData.ts), a ideia é uma maior ajuda para adiconar mais conteúdos e sugestoes. 